### PR TITLE
Add action to build maven project in repository

### DIFF
--- a/.github/workflows/java_compilier.yml
+++ b/.github/workflows/java_compilier.yml
@@ -1,7 +1,9 @@
 name: Java CI with Maven
 on:
+  push:
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Add action to build maven project in repository

Fixes part of #111 

Based on this:
https://github.com/shreeshailaya/C-DAC-Notes/actions/runs/1368774392
Also defined jobs to fix the error.
`No jobs defined in jobs`